### PR TITLE
Add HL7 custom template folder support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
     <RepositoryUrl>https://github.com/microsoft/fhir-server</RepositoryUrl>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)\CodeCoverage.runsettings</RunSettingsFilePath>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/docs/ConvertDataOperation.md
+++ b/docs/ConvertDataOperation.md
@@ -117,3 +117,9 @@ Make a call to the $convert-data API specifying your template reference in the t
 `<RegistryServer>/<imageName>@<imageDigest>`
 
 `<RegistryServer>/<imageName>:<imageTag>` 
+
+Added support to replace "microsofthealth/hl7v2templates:default" in cache with custom templates from a specified .tar.gz file
+in FhirServer__Operations__ConvertData__CustomHl7TemplatesFile configuration. 
+Make sure the rootTemplate *.liquid files are in package root, not under a folder. Sample command to create Hl7v2.tar.gz package from "Hl7v2" templates folder:
+``tar -czf Hl7v2.tar.gz -C Hl7v2 .``
+You can put custom templates as tar.gz package in a folder or volume mount and set ``microsofthealth/hl7v2templates:default`` as templateCollectionReference. Also set FhirServer__Operations__ConvertData__CustomHl7TemplatesFile configuration like "/app/Templates/Hl7v2.tar.gz"

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -57,5 +57,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Enable the performance telemetry logging.
         /// </summary>
         public bool EnableTelemetryLogger { get; set; } = false;
+
+        /// <summary>
+        /// Custom HL7 templates file in tar.gz package to use for TemplateCollectionReference "microsofthealth/hl7v2templates:default".
+        /// e.g: "/app/Templates/Hl7v2.tar.gz"
+        /// </summary>
+        public string CustomHl7TemplatesFile { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DotLiquid;
@@ -15,8 +17,10 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData.Models;
 using Microsoft.Health.Fhir.Core.Messages.ConvertData;
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
 using Microsoft.Health.Fhir.TemplateManagement;
 using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
+using Microsoft.Health.Fhir.TemplateManagement.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 {
@@ -46,6 +50,47 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
             });
 
             _templateCollectionProviderFactory = new TemplateCollectionProviderFactory(_cache, Options.Create(_convertDataConfig.TemplateCollectionOptions));
+            AddCustomTHl7emplatesFromFolder();
+        }
+
+        /// <summary>
+        /// Replace "microsofthealth/hl7v2templates:default" in cache with custom templates from a specified .tar.gz file
+        /// in FhirServer__Operations__ConvertData__CustomHl7TemplatesFile configuration. Can use path from shared volume too.
+        /// Make sure the rootTemplate *.liquid files are in package root, not under a folder.
+        /// </summary>
+        /// <exception cref="DefaultTemplatesInitializeException">Thrown when template load fails</exception>
+        private void AddCustomTHl7emplatesFromFolder()
+        {
+            if (string.IsNullOrWhiteSpace(_convertDataConfig.CustomHl7TemplatesFile))
+            {
+                _logger.LogInformation("FhirServer__Operations__ConvertData__CustomHl7TemplatesFile is not set.");
+
+                // Do nothing
+                return;
+            }
+
+            if (!File.Exists(_convertDataConfig.CustomHl7TemplatesFile))
+            {
+                throw new DefaultTemplatesInitializeException(
+                    TemplateManagementErrorCode.InitializeDefaultTemplateFailed,
+                    $"Load custom HL7 template failed. Path not found: {_convertDataConfig.CustomHl7TemplatesFile}");
+            }
+
+            _logger.LogInformation($"FhirServer__Operations__ConvertData__CustomHl7TemplatesFile is set to '{_convertDataConfig.CustomHl7TemplatesFile}.");
+            var defaultHl7TemplateImageReference = "microsofthealth/hl7v2templates:default";
+            var templateInfo = new DefaultTemplateInfo(DataType.Hl7v2, defaultHl7TemplateImageReference, _convertDataConfig.CustomHl7TemplatesFile);
+            _templateCollectionProviderFactory.InitDefaultTemplates(templateInfo);
+            if (_cache.TryGetValue(defaultHl7TemplateImageReference, out TemplateLayer template) &&
+                 template.TemplateContent.Keys.Any(key => key.StartsWith("ADT_A", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                _logger.LogInformation($"Using custom template collection '{_convertDataConfig.CustomHl7TemplatesFile}' for '{defaultHl7TemplateImageReference}'.");
+            }
+            else
+            {
+                throw new DefaultTemplatesInitializeException(
+                    TemplateManagementErrorCode.ParseTemplatesFailed,
+                    $"Load custom HL7 template failed. RootTemplate ADT files not found in root of package: {_convertDataConfig.CustomHl7TemplatesFile}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Added support to replace "microsofthealth/hl7v2templates:default" in cache with custom templates from a specified .tar.gz file
in FhirServer__Operations__ConvertData__CustomHl7TemplatesFile configuration. 
Make sure the rootTemplate *.liquid files are in package root, not under a folder. Sample command to create Hl7v2.tar.gz package from "Hl7v2" templates folder:
``tar -czf Hl7v2.tar.gz -C Hl7v2 .``
You can put custom templates as tar.gz package in a folder or volume mount and set ``microsofthealth/hl7v2templates:default`` as templateCollectionReference. Also set FhirServer__Operations__ConvertData__CustomHl7TemplatesFile configuration like "/app/Templates/Hl7v2.tar.gz"

## Testing
Install fhir-server with FhirServer__Operations__ConvertData__CustomHl7TemplatesFile configuration set with custom templates like "/app/Templates/Hl7v2.tar.gz" and set ``microsofthealth/hl7v2templates:default`` as templateCollectionReference while posting convert request. 
